### PR TITLE
fix for flickering when typing fast

### DIFF
--- a/meme.js
+++ b/meme.js
@@ -99,7 +99,10 @@ window.Meme = function(image, canvas, top, bottom) {
 		canvas.width = w;
 		canvas.height = h;
 	};
-	setCanvasDimensions(image.width, image.height);	
+	
+	if (canvas.width != image.width || canvas.height != image.height) {
+		setCanvasDimensions(image.width, image.height);	
+	}
 
 	/*
 	Draw a centered meme string


### PR DESCRIPTION
When typing fast the image flickers. I found out that it's due to setting canvas width/height each time, even if it's not necessary. Fix for this is to set canvas dimensions only if its current size is different from the image data.
