### PR TITLE
Add syntax highlighting to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,30 @@ Use one function to generate a meme.
 
 You can call it all with strings:
 
-     Meme('dog.jpg', 'canvasID', 'Buy pizza, 'Pay in snakes');
+```javascript
+Meme('dog.jpg', 'canvasID', 'Buy pizza', 'Pay in snakes');
+```
 
 Or with a selected canvas element:
 
-     var canvas = document.getElementById('canvasID');
-     Meme('wolf.jpg', canvas, 'The time is now', 'to take what\'s yours');
+```javascript
+var canvas = document.getElementById('canvasID');
+Meme('wolf.jpg', canvas, 'The time is now', 'to take what\'s yours');
+```
 
 Or with a jQuery/Zepto selection:
 
-     Meme('spidey.jpg', $('#canvasID'), 'Did someone say', 'Spiderman JS?');
+```javascript
+Meme('spidey.jpg', $('#canvasID'), 'Did someone say', 'Spiderman JS?');
+```
 
 You can also pass in an image:
 
-     var img = new Image();
-     img.src = 'insanity.jpg';
-     var can = document.getElementById('canvasID');
-     Meme(img, can, 'you ignore my calls', 'I ignore your screams of mercy');
+```javascript
+var img = new Image();
+img.src = 'insanity.jpg';
+var can = document.getElementById('canvasID');
+Meme(img, can, 'you ignore my calls', 'I ignore your screams of mercy');
+```
 
 License info is in LICENSE.txt.


### PR DESCRIPTION
Also fixed a syntax error. Missing a `'` in the first example.